### PR TITLE
Fix the compile problem

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -4,7 +4,7 @@ Import('rtconfig')
 src   = []
 cwd   = GetCurrentDir()
 
-src += ['libraries/*.c']
+src += Glob(cwd + '/libraries/*.c')
 
 if GetDepend('PKG_BMI160_BMX160_USING_SENSOR_V1'):
     src += ['sensor_bosch_bmx160.c']


### PR DESCRIPTION
The problem is that the scons would try to find files called "*.c" rather than adding all source files in /libraries forlder to compile